### PR TITLE
Callback phase fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    omniauth-telegram (1.0.0)
+    omniauth-telegram (0.1.0)
       omniauth (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    hashie (3.5.7)
-    omniauth (1.8.1)
-      hashie (>= 3.4.6, < 3.6.0)
+    hashie (3.6.0)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    rack (2.0.5)
+    rack (2.0.7)
     rake (10.5.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -38,4 +38,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/lib/omniauth/strategies/telegram.rb
+++ b/lib/omniauth/strategies/telegram.rb
@@ -46,15 +46,15 @@ module OmniAuth
       
       def callback_phase
         unless FIELDS.all? { |f| request.params.include?(f) }
-          fail!(:field_missing)
+          fail!(:field_missing) && return
         end
         
         unless check_signature
-          fail!(:signature_mismatch)
+          fail!(:signature_mismatch) && return
         end
         
         if Time.now.to_i - request.params["auth_date"].to_i > 86400
-          fail!(:session_expired)
+          fail!(:session_expired) && return
         end
         
         super


### PR DESCRIPTION
in callback_phase `super` was called even if failure occured, which caused
to an undesired behavior. I.e. hash is invalid, `on_failure` callback is
fired and redirects to something, but right after that `super` is called
and `callback` action is triggered and `on_failure`'s output is lost.