### PR TITLE
Fix trailing space for users without a last name

### DIFF
--- a/lib/omniauth/strategies/telegram.rb
+++ b/lib/omniauth/strategies/telegram.rb
@@ -58,7 +58,8 @@ module OmniAuth
 
       info do
         {
-            name:       "#{request.params["first_name"]} #{request.params["last_name"]}",
+            name:       full_name(request.params["first_name"],
+                                  request.params["last_name"]),
             nickname:   request.params["username"],
             first_name: request.params["first_name"],
             last_name:  request.params["last_name"],
@@ -73,6 +74,14 @@ module OmniAuth
       end
 
       private
+
+      def full_name(first_name, last_name=nil)
+        if last_name
+          "#{first_name} #{last_name}"
+        else
+          first_name
+        end
+      end
 
       def check_errors
         return :field_missing unless check_required_fields


### PR DESCRIPTION
On Telegram, users can have their last name not set. Constructing a full name like `"#{request.params["first_name"]} #{request.params["last_name"]}"` with `last_name = nil` then gives you the first name with a space at the end. To fix this, I added a private function to your strategy that checks if there's a last name. If yes, it will build the full name the same way. If not, it will just return the first name, without a space at the end.